### PR TITLE
add third argument to open()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -392,7 +392,7 @@ int main(int argc, char *argv[])
 	parse_header(fd);
 
 	if (outfile != NULL) {
-		fdo = open(outfile, O_WRONLY | O_CREAT);
+		fdo = open(outfile, O_WRONLY | O_CREAT, 0777);
 		if (fdo == -1) {
 			fprintf(stderr, "Failed to open '%s'.\n", outfile);
 			perror("");


### PR DESCRIPTION
Hi!

Just got this error at ```fdo = open(outfile, O_WRONLY | O_CREAT);``` on Ubuntu 16.04 while running ```make```:

``` error: call to ‘__open_missing_mode’ declared with attribute error: open with O_CREAT or O_TMPFILE in second argument needs 3 arguments```

Maybe it could be happen not only at me.